### PR TITLE
Feat/base generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.2.0] - 2017-08-07
+### Added
+- `--minitest` option to specify you're using minitest.
+- `--rspec` option to specify you're using minitest. It is the default behaviour.
+- `--no-suffix` option to specify you don't want any suffixes.
+### Changed
+- Get back to using suffixes by default.
+### Removed
+- `--test-suite` option to specify which test suite you're using.
 
 ## [0.1.5] - 2017-08-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ end
 
 ## Options
 
-* `--test-suite`
+* `--minitest`
+  * Will create your test files inside test folder. 
+* DEFAULT: `--rspec`
+  * Will create your test files inside spec folder.
 
-  * Specify the test suite to generate the test files with. (`minitest` or `rspec`).
-  * DEFAULT: `rspec`
-  * Usage: `rails generate service subscribe_user --test-suite=minitest`
+* Usage: `rails generate service subscribe_user --minitest`
 
 
 ## Where can I learn about more patterns?
@@ -155,3 +156,4 @@ This project respects the [contributor code of conduct](https://github.com/sungw
 ## License
 
 This project rocks and uses MIT-LICENSE.
+

--- a/lib/generators/base_generator.rb
+++ b/lib/generators/base_generator.rb
@@ -1,0 +1,57 @@
+require "active_support/inflector"
+
+# Base class for all generators to come. If you want to override some behaviour, all you
+# got to do is override a method in the child class.
+class BaseGenerator < Rails::Generators::NamedBase
+  class_option :rspec, type: :boolean, desc: 'DEFAULT: Define rspec as your test framework.'
+  class_option :minitest, type: :boolean, desc: 'Test framework to generate test. (rspec or minitest)'
+  class_option :no_suffix, type: :boolean, desc: "If you don't want any pattern suffix. Ex: AuthenticationService. Service is the suffix."
+
+  # Creates the file for the requested pattern based on a template file.
+  def copy_service_file
+    template "#{pattern_name}.rb", generated_file_path
+  end
+
+  # Creates the test file for the request pattern based on a template file.
+  def copy_forms_test_file
+    template "#{pattern_name}_#{test_suite_identifier}.rb", generated_test_file_path
+  end
+
+  private
+
+  # Determines the class name based on the file name given by the user.
+  def class_name
+    file_name.classify
+  end
+
+  # This method must be overrided in the child classes.
+  def pattern_name
+    raise NotImplementedError
+  end
+
+  def folder_name
+    pattern_name.pluralize
+  end
+
+  def suffix
+    no_suffix? ? "" : pattern_name.classify
+  end
+
+  # Generates the file path.
+  # Ex: app/services/authentication.rb
+  def generated_file_path
+    "app/#{folder_name}/#{file_name}.rb"
+  end
+
+  def test_suite_identifier
+    identifier = "spec"
+    identifier = "test" if options.minitest?
+    identifier
+  end
+
+  # Generates the test file path.
+  # Ex: spec/services/authentication_spec.rb
+  def generated_test_file_path
+    "#{test_suite_identifier}/#{folder_name}/#{file_name}_#{test_suite_identifier}.rb"
+  end
+end

--- a/lib/generators/base_generator.rb
+++ b/lib/generators/base_generator.rb
@@ -21,7 +21,7 @@ class BaseGenerator < Rails::Generators::NamedBase
 
   # Determines the class name based on the file name given by the user.
   def class_name
-    file_name.classify
+    file_name.classify + suffix.classify
   end
 
   # This method must be overrided in the child classes.
@@ -33,14 +33,16 @@ class BaseGenerator < Rails::Generators::NamedBase
     pattern_name.pluralize
   end
 
+  # Generates the pattern suffix.
+  # Ex: _service
   def suffix
-    no_suffix? ? "" : pattern_name.classify
+    options.no_suffix? ? "" : "_#{pattern_name}"
   end
 
   # Generates the file path.
   # Ex: app/services/authentication.rb
   def generated_file_path
-    "app/#{folder_name}/#{file_name}.rb"
+    "app/#{folder_name}/#{file_name}#{suffix}.rb"
   end
 
   def test_suite_identifier
@@ -52,6 +54,6 @@ class BaseGenerator < Rails::Generators::NamedBase
   # Generates the test file path.
   # Ex: spec/services/authentication_spec.rb
   def generated_test_file_path
-    "#{test_suite_identifier}/#{folder_name}/#{file_name}_#{test_suite_identifier}.rb"
+    "#{test_suite_identifier}/#{folder_name}/#{file_name}#{suffix}_#{test_suite_identifier}.rb"
   end
 end

--- a/lib/generators/form/form_generator.rb
+++ b/lib/generators/form/form_generator.rb
@@ -1,26 +1,9 @@
-require "active_support/inflector"
-
-class FormGenerator < Rails::Generators::NamedBase
-  source_root File.expand_path('../templates', __FILE__)
-  class_option :test_suite, type: :string, default: 'rspec', desc: 'Test framework to generate test. (rspec or minitest)'
-
-  PATTERN_NAME = "form"
-
-  def copy_service_file
-    template "#{PATTERN_NAME}.rb", "app/#{PATTERN_NAME.pluralize}/#{file_name}.rb"
-  end
-
-  def copy_forms_test_file
-    if options.test_suite == 'rspec'
-      template "#{PATTERN_NAME}_spec.rb", "spec/#{PATTERN_NAME.pluralize}/#{file_name}_spec.rb"
-    elsif options.test_suite == 'minitest'
-      template "#{PATTERN_NAME}_test.rb", "test/#{PATTERN_NAME.pluralize}/#{file_name}_test.rb"
-    end
-  end
+class FormGenerator < BaseGenerator
+  source_root File.expand_path("../templates", __FILE__)
 
   private
 
-  def class_name
-    file_name.classify
+  def pattern_name
+    "form"
   end
 end

--- a/lib/generators/policy/policy_generator.rb
+++ b/lib/generators/policy/policy_generator.rb
@@ -1,24 +1,9 @@
-require 'active_support/inflector'
-
-class PolicyGenerator < Rails::Generators::NamedBase
+class PolicyGenerator < BaseGenerator
   source_root File.expand_path('../templates', __FILE__)
-  class_option :test_suite, type: :string, default: 'rspec', desc: 'Test framework to generate test. (rspec or minitest)'
-
-  def generate_template
-    template 'policy.rb', "app/policies/#{file_name}.rb"
-  end
-
-  def generate_test
-    if options.test_suite == 'rspec'
-      template 'policy_spec.rb', "spec/policies/#{file_name}_spec.rb"
-    elsif options.test_suite == 'minitest'
-      template 'policy_test.rb', "test/policies/#{file_name}_test.rb"
-    end
-  end
 
   private
 
-  def class_name
-    file_name.classify
+  def pattern_name
+    "policy"
   end
 end

--- a/lib/generators/poro/poro_generator.rb
+++ b/lib/generators/poro/poro_generator.rb
@@ -1,24 +1,13 @@
-require 'active_support/inflector'
-
-class PoroGenerator < Rails::Generators::NamedBase
+class PoroGenerator < BaseGenerator
   source_root File.expand_path('../templates', __FILE__)
-  class_option :test_suite, type: :string, default: 'rspec', desc: 'Test framework to generate test. (rspec or minitest)'
-
-  def generate_template
-    template 'poro.rb', "app/models/#{file_name}.rb"
-  end
-
-  def generate_test
-    if options.test_suite == 'rspec'
-      template 'poro_spec.rb', "spec/models/#{file_name}_spec.rb"
-    elsif options.test_suite == 'minitest'
-      template 'poro_test.rb', "test/models/#{file_name}_test.rb"
-    end
-  end
 
   private
 
-  def class_name
-    file_name.classify
+  def folder_name
+    "models"
+  end
+
+  def pattern_name
+    "poro"
   end
 end

--- a/lib/generators/poro/poro_generator.rb
+++ b/lib/generators/poro/poro_generator.rb
@@ -10,4 +10,8 @@ class PoroGenerator < BaseGenerator
   def pattern_name
     "poro"
   end
+
+  def suffix
+    ""
+  end
 end

--- a/lib/generators/service/service_generator.rb
+++ b/lib/generators/service/service_generator.rb
@@ -1,24 +1,9 @@
-require "active_support/inflector"
-
-class ServiceGenerator < Rails::Generators::NamedBase
+class ServiceGenerator < BaseGenerator
   source_root File.expand_path('../templates', __FILE__)
-  class_option :test_suite, type: :string, default: 'rspec', desc: 'Test framework to generate test. (rspec or minitest)'
-
-  def copy_service_file
-    template 'service.rb', "app/services/#{file_name}.rb"
-  end
-
-  def copy_service_test_file
-    if options.test_suite == 'rspec'
-      template 'service_spec.rb', "spec/services/#{file_name}_spec.rb"
-    elsif options.test_suite == 'minitest'
-      template 'service_test.rb', "test/services/#{file_name}_test.rb"
-    end
-  end
 
   private
 
-  def class_name
-    file_name.classify
+  def pattern_name
+    "service"
   end
 end

--- a/lib/pattern_generator.rb
+++ b/lib/pattern_generator.rb
@@ -1,4 +1,10 @@
 require "rails/generators"
 
+require_relative "./generators/base_generator"
+
+%w(form policy poro service).each do |pattern|
+  require_relative "./generators/#{pattern}/#{pattern}_generator"
+end
+
 module PatternGenerator
 end

--- a/lib/pattern_generator/version.rb
+++ b/lib/pattern_generator/version.rb
@@ -1,3 +1,3 @@
 module PatternGenerator
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/test/generators/form_generator_test.rb
+++ b/test/generators/form_generator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'generators/form/form_generator'
 
 class FormGeneratorTest < Rails::Generators::TestCase
   tests FormGenerator
@@ -32,7 +31,7 @@ class FormGeneratorTest < Rails::Generators::TestCase
   end
 
   test 'generates minitest file if test-framework is minitest' do
-    run_generator %w(registration --test-suite=minitest)
+    run_generator %w(registration --minitest)
 
     assert_file 'test/forms/registration_test.rb' do |content|
       assert_match /class RegistrationTest < Minitest::Test/, content

--- a/test/generators/form_generator_test.rb
+++ b/test/generators/form_generator_test.rb
@@ -30,11 +30,24 @@ class FormGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test 'generates minitest file if test-framework is minitest' do
+  test 'generates minitest file if --minitest options is passed' do
     run_generator %w(registration --minitest)
 
     assert_file 'test/forms/registration_form_test.rb' do |content|
       assert_match /class RegistrationFormTest < Minitest::Test/, content
+    end
+  end
+
+  test 'generates files with no suffixes if --no-sufix option is passed' do
+    run_generator %w(registration --no-suffix)
+
+    assert_file 'app/forms/registration.rb' do |content|
+      assert_match /Registration/, content
+      assert_match /def initialize/, content
+    end
+
+    assert_file 'spec/forms/registration_spec.rb' do |content|
+      assert_match /RSpec.describe Registration, type: :form/, content
     end
   end
 end

--- a/test/generators/form_generator_test.rb
+++ b/test/generators/form_generator_test.rb
@@ -15,8 +15,8 @@ class FormGeneratorTest < Rails::Generators::TestCase
   test 'correct file is generated' do
     run_generator %w(registration)
 
-    assert_file 'app/forms/registration.rb' do |content|
-      assert_match /Registration/, content
+    assert_file 'app/forms/registration_form.rb' do |content|
+      assert_match /RegistrationForm/, content
       assert_match /def initialize/, content
     end
   end
@@ -24,8 +24,8 @@ class FormGeneratorTest < Rails::Generators::TestCase
   test 'correct spec file is generated' do
     run_generator %w(registration)
 
-    assert_file 'spec/forms/registration_spec.rb' do |content|
-      assert_match /RSpec.describe Registration, type: :form/, content
+    assert_file 'spec/forms/registration_form_spec.rb' do |content|
+      assert_match /RSpec.describe RegistrationForm, type: :form/, content
       assert_match /pending/, content
     end
   end
@@ -33,8 +33,8 @@ class FormGeneratorTest < Rails::Generators::TestCase
   test 'generates minitest file if test-framework is minitest' do
     run_generator %w(registration --minitest)
 
-    assert_file 'test/forms/registration_test.rb' do |content|
-      assert_match /class RegistrationTest < Minitest::Test/, content
+    assert_file 'test/forms/registration_form_test.rb' do |content|
+      assert_match /class RegistrationFormTest < Minitest::Test/, content
     end
   end
 end

--- a/test/generators/policy_generator_test.rb
+++ b/test/generators/policy_generator_test.rb
@@ -16,8 +16,8 @@ class PolicyGeneratorTest < Rails::Generators::TestCase
   test "correct file is generated" do
     run_generator %w(active_user)
 
-    assert_file 'app/policies/active_user.rb' do |content|
-      assert_match /class ActiveUser/, content
+    assert_file 'app/policies/active_user_policy.rb' do |content|
+      assert_match /class ActiveUserPolicy/, content
       assert_match /def initialize/, content
     end
   end
@@ -25,8 +25,8 @@ class PolicyGeneratorTest < Rails::Generators::TestCase
   test "rspec file is generated" do
     run_generator %w(active_user)
 
-    assert_file 'spec/policies/active_user_spec.rb' do |content|
-      assert_match /RSpec.describe ActiveUser, type: :policy do/, content
+    assert_file 'spec/policies/active_user_policy_spec.rb' do |content|
+      assert_match /RSpec.describe ActiveUserPolicy, type: :policy do/, content
       assert_match /pending/, content
     end
   end
@@ -34,8 +34,8 @@ class PolicyGeneratorTest < Rails::Generators::TestCase
   test "if minitest is specified, minitest file is generated" do
     run_generator %w(active_user --minitest)
 
-    assert_file 'test/policies/active_user_test.rb' do |content|
-      assert_match /class ActiveUserTest < Minitest::Test/, content
+    assert_file 'test/policies/active_user_policy_test.rb' do |content|
+      assert_match /class ActiveUserPolicyTest < Minitest::Test/, content
     end
   end
 

--- a/test/generators/policy_generator_test.rb
+++ b/test/generators/policy_generator_test.rb
@@ -39,4 +39,16 @@ class PolicyGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test 'generates files with no suffixes if --no-sufix option is passed' do
+    run_generator %w(active_user --no-suffix)
+
+    assert_file 'app/policies/active_user.rb' do |content|
+      assert_match /ActiveUser/, content
+      assert_match /def initialize/, content
+    end
+
+    assert_file 'spec/policies/active_user_spec.rb' do |content|
+      assert_match /RSpec.describe ActiveUser, type: :policy/, content
+    end
+  end
 end

--- a/test/generators/policy_generator_test.rb
+++ b/test/generators/policy_generator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'generators/policy/policy_generator'
 
 class PolicyGeneratorTest < Rails::Generators::TestCase
   tests PolicyGenerator
@@ -33,7 +32,7 @@ class PolicyGeneratorTest < Rails::Generators::TestCase
   end
 
   test "if minitest is specified, minitest file is generated" do
-    run_generator %w(active_user --test-suite=minitest)
+    run_generator %w(active_user --minitest)
 
     assert_file 'test/policies/active_user_test.rb' do |content|
       assert_match /class ActiveUserTest < Minitest::Test/, content

--- a/test/generators/poro_generator_test.rb
+++ b/test/generators/poro_generator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'generators/poro/poro_generator'
 
 class PoroGeneratorTest < Rails::Generators::TestCase
   tests PoroGenerator
@@ -31,7 +30,7 @@ class PoroGeneratorTest < Rails::Generators::TestCase
   end
 
   test 'minitest file is generated when test-suite is minitest' do
-    run_generator %w(grade --test-suite=minitest)
+    run_generator %w(grade --minitest)
 
     assert_file 'test/models/grade_test.rb' do |content|
       assert_match /class GradeTest < MiniTest::Test/, content

--- a/test/generators/service_generator_test.rb
+++ b/test/generators/service_generator_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'generators/service/service_generator'
 
 class ServiceGeneratorTest < Rails::Generators::TestCase
   tests ServiceGenerator
@@ -32,7 +31,7 @@ class ServiceGeneratorTest < Rails::Generators::TestCase
   end
 
   test 'generates minitest file if test-framework is minitest' do
-    run_generator %w(find_match --test-suite=minitest)
+    run_generator %w(find_match --minitest)
 
     assert_file 'test/services/find_match_test.rb' do |content|
       assert_match /class FindMatchTest < Minitest::Test/, content

--- a/test/generators/service_generator_test.rb
+++ b/test/generators/service_generator_test.rb
@@ -15,8 +15,8 @@ class ServiceGeneratorTest < Rails::Generators::TestCase
   test 'correct file is generated' do
     run_generator %w(find_match)
 
-    assert_file 'app/services/find_match.rb' do |content|
-      assert_match /FindMatch/, content
+    assert_file 'app/services/find_match_service.rb' do |content|
+      assert_match /class FindMatchService/, content
       assert_match /def initialize/, content
     end
   end
@@ -24,8 +24,8 @@ class ServiceGeneratorTest < Rails::Generators::TestCase
   test 'correct spec file is generated' do
     run_generator %w(find_match)
 
-    assert_file 'spec/services/find_match_spec.rb' do |content|
-      assert_match /RSpec.describe FindMatch, type: :service/, content
+    assert_file 'spec/services/find_match_service_spec.rb' do |content|
+      assert_match /RSpec.describe FindMatchService, type: :service/, content
       assert_match /pending/, content
     end
   end
@@ -33,8 +33,8 @@ class ServiceGeneratorTest < Rails::Generators::TestCase
   test 'generates minitest file if test-framework is minitest' do
     run_generator %w(find_match --minitest)
 
-    assert_file 'test/services/find_match_test.rb' do |content|
-      assert_match /class FindMatchTest < Minitest::Test/, content
+    assert_file 'test/services/find_match_service_test.rb' do |content|
+      assert_match /class FindMatchServiceTest < Minitest::Test/, content
     end
   end
 end

--- a/test/generators/service_generator_test.rb
+++ b/test/generators/service_generator_test.rb
@@ -37,4 +37,17 @@ class ServiceGeneratorTest < Rails::Generators::TestCase
       assert_match /class FindMatchServiceTest < Minitest::Test/, content
     end
   end
+
+  test 'generates files with no suffixes if --no-sufix option is passed' do
+    run_generator %w(find_match --no-suffix)
+
+    assert_file 'app/services/find_match.rb' do |content|
+      assert_match /FindMatch/, content
+      assert_match /def initialize/, content
+    end
+
+    assert_file 'spec/services/find_match_spec.rb' do |content|
+      assert_match /RSpec.describe FindMatch, type: :service/, content
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,13 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
-require "rails/test_help"
 require "byebug"
+
+require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
+
+require "rails/test_help"
+
+ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
@@ -18,3 +21,4 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
   ActiveSupport::TestCase.fixtures :all
 end
+


### PR DESCRIPTION
### Added
- `--minitest` option to specify you're using minitest.
- `--rspec` option to specify you're using minitest. It is the default behaviour.
- `--no-suffix` option to specify you don't want any suffixes.
### Changed
- Get back to using suffixes by default.
### Removed
- `--test-suite` option to specify which test suite you're using.